### PR TITLE
Setup Vite with Tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,36 +8,41 @@ SeatPlanner 是一款用於活動或場地座位規劃的前端應用程式，�
 - **座位編號與群體分配**：可根據座位編號或群體名單自動配置座位，支援快速重新編號。
 - **座位圖匯出**：設計完成後可以下載 PNG 圖檔，方便列印或分享。
 
+
 ## 如何在本地端啟動
 
-本專案為純前端網頁，只需瀏覽器即可執行。建議使用簡易的本地伺服器開啟，以避免部分瀏覽器的跨域限制。
+本專案使用 Vite 進行開發與建置，請先確認已安裝 Node.js。
 
-1. 安裝需求：任一現代瀏覽器（Chrome、Firefox 等）。若要自行打包程式碼，需安裝 Node.js 與 Python 3。
-2. 下載或複製此專案檔案到本地端。
-3. （選擇性）安裝相依套件並產生 `bundle.js`：
+1. 下載或複製此專案。
+2. 安裝相依套件：
    ```bash
    npm install
-   npm run build
    ```
-4. 在專案根目錄啟動伺服器：
+3. 啟動開發伺服器：
    ```bash
-   python3 -m http.server
+   npm run dev
    ```
-5. 開啟瀏覽器並前往 <http://localhost:8000/index.html> 即可開始使用。
-
-若只想快速查看，也可以直接以瀏覽器打開 `index.html` 檔案。
+   依照終端機顯示的網址開啟瀏覽器（預設 http://localhost:5173/）。
+4. 建置正式版並預覽：
+   ```bash
+   npm run build
+   npm run preview
+   ```
 
 ## 專案結構
 
 ```
 SeatPlanner/
-├── index.html      # 入口 HTML
-├── src/            # React 原始碼
+├── index.html           # 入口 HTML
+├── src/                 # React 原始碼
 │   ├── main.jsx
 │   ├── SeatingDesigner.jsx
-│   └── icons.js
-├── webpack.config.js
-└── README.md       # 專案說明文件
+│   ├── icons.js
+│   └── index.css
+├── vite.config.js
+├── tailwind.config.js
+├── postcss.config.js
+└── README.md            # 專案說明文件
 ```
 
 ## 貢獻方式

--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>會場座位設計系統</title>
     
-    <script src="https://cdn.tailwindcss.com"></script>
     
     <!-- 自定義樣式 -->
     <style>
@@ -54,6 +53,6 @@
         }
     </style>
 
-    <script src="dist/bundle.js"></script>
+    <script type="module" src="/src/main.jsx"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -2,17 +2,19 @@
   "name": "seatplanner",
   "version": "1.0.0",
   "scripts": {
-    "build": "webpack"
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.21.0",
-    "@babel/preset-react": "^7.18.6",
-    "babel-loader": "^9.1.2",
-    "webpack": "^5.88.2",
-    "webpack-cli": "^5.1.4"
+    "vite": "^4.4.0",
+    "tailwindcss": "^3.3.2",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14",
+    "@vitejs/plugin-react": "^4.0.0"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import './index.css';
 import SeatingDesigner from './SeatingDesigner';
 
 function initApp() {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- add package.json with Vite and Tailwind
- configure Tailwind and PostCSS
- import Tailwind in React entry
- update index.html to load the Vite bundle
- document new install/start commands in Chinese

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68525935f2e083258c97de4cc1a62f55