### PR TITLE
Refactor SeatingDesigner into smaller components

### DIFF
--- a/src/SeatingDesigner.jsx
+++ b/src/SeatingDesigner.jsx
@@ -1,5 +1,8 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Users, Plus, Shuffle, Save, RotateCcw, Edit3, Move, Hand, Download } from "./icons";
+import { Plus, Shuffle, RotateCcw } from "./icons";
+import Toolbar from "./components/Toolbar";
+import SeatTools from "./components/SeatTools";
+import ExportPanel from "./components/ExportPanel";
 const SeatingDesigner = () => {
   const canvasRef = useRef(null);
   const [mode, setMode] = useState('design');
@@ -971,130 +974,23 @@ const SeatingDesigner = () => {
   
   return React.createElement('div', { className: "min-h-screen bg-gray-50 p-4" },
     React.createElement('div', { className: "max-w-7xl mx-auto" },
-      // 標題
-      React.createElement('div', { className: "bg-white rounded-lg shadow-md p-6 mb-6" },
-        React.createElement('h1', { className: "text-2xl font-bold text-gray-800 mb-2 flex items-center" },
-          React.createElement(Users, { className: "mr-3 text-blue-600" }),
-          "會場座位設計系統"
-        ),
-        React.createElement('p', { className: "text-gray-600" }, "拖拉設計會場佈局，智慧分配座位，支援缺角座位設計")
-      ),
-      
-      // 模式切換
-      React.createElement('div', { className: "bg-white rounded-lg shadow-md p-4 mb-6" },
-        React.createElement('div', { className: "flex space-x-4" },
-          React.createElement('button', {
-            onClick: () => setMode('design'),
-            className: `px-4 py-2 rounded-md flex items-center ${mode === 'design' ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-700'}`
-          },
-            React.createElement(Edit3, { className: "w-4 h-4 mr-2" }),
-            "設計模式"
-          ),
-          React.createElement('button', {
-            onClick: () => setMode('assign'),
-            className: `px-4 py-2 rounded-md flex items-center ${mode === 'assign' ? 'bg-green-600 text-white' : 'bg-gray-200 text-gray-700'}`
-          },
-            React.createElement(Users, { className: "w-4 h-4 mr-2" }),
-            "分配模式"
-          )
-        ),
-        
-        // 設計子模式
-        mode === 'design' && React.createElement('div', { className: "flex space-x-2 mt-4 pt-4 border-t" },
-          React.createElement('button', {
-            onClick: () => setDesignMode('create'),
-            className: `px-3 py-2 rounded-md flex items-center text-sm ${designMode === 'create' ? 'bg-purple-600 text-white' : 'bg-gray-100 text-gray-700'}`
-          },
-            React.createElement(Plus, { className: "w-4 h-4 mr-1" }),
-            "創建區塊"
-          ),
-          React.createElement('button', {
-            onClick: () => setDesignMode('move'),
-            className: `px-3 py-2 rounded-md flex items-center text-sm ${designMode === 'move' ? 'bg-purple-600 text-white' : 'bg-gray-100 text-gray-700'}`
-          },
-            React.createElement(Hand, { className: "w-4 h-4 mr-1" }),
-            "移動區塊"
-          ),
-          React.createElement('button', {
-            onClick: () => setDesignMode('edit'),
-            className: `px-3 py-2 rounded-md flex items-center text-sm ${designMode === 'edit' ? 'bg-purple-600 text-white' : 'bg-gray-100 text-gray-700'}`
-          },
-            React.createElement(Edit3, { className: "w-4 h-4 mr-1" }),
-            "編輯座位"
-          ),
-          React.createElement('button', {
-            onClick: () => setDesignMode('pan'),
-            className: `px-3 py-2 rounded-md flex items-center text-sm ${designMode === 'pan' ? 'bg-purple-600 text-white' : 'bg-gray-100 text-gray-700'}`
-          },
-            React.createElement(Move, { className: "w-4 h-4 mr-1" }),
-            "移動畫布"
-          )
-        )
-      ),
+      React.createElement(Toolbar, { mode, setMode, designMode, setDesignMode }),
       
       React.createElement('div', { className: "grid grid-cols-1 lg:grid-cols-4 gap-6" },
         // 左側工具面板
         React.createElement('div', { className: "space-y-6" },
           // 設計工具
-          mode === 'design' && React.createElement('div', { className: "bg-white rounded-lg shadow-md p-4" },
-            React.createElement('h3', { className: "font-semibold mb-3" }, "設計工具"),
-            
-            designMode === 'create' && React.createElement('div', { className: "space-y-2" },
-              Object.entries(toolStyles).map(([tool, style]) =>
-                React.createElement('button', {
-                  key: tool,
-                  onClick: () => setCurrentTool(tool),
-                  className: `w-full p-3 rounded-md border-2 flex items-center ${currentTool === tool ? 'border-blue-500 bg-blue-50' : 'border-gray-200 hover:border-gray-300'}`
-                },
-                  React.createElement('div', { 
-                    className: "w-4 h-4 rounded mr-3",
-                    style: { backgroundColor: style.color }
-                  }),
-                  style.label
-                )
-              ),
-              
-              currentTool === 'seat' && React.createElement('div', { className: "mt-4 pt-4 border-t" },
-                React.createElement('p', { className: "text-xs text-gray-500" },
-                  "座位數量完全根據拖拉區域大小決定，座位編號會自動連續排列"
-                )
-              )
-            ),
-            
-            designMode === 'move' && React.createElement('p', { className: "text-sm text-gray-600" }, "點擊並拖動區塊來移動位置"),
-            
-            designMode === 'edit' && React.createElement('div', null,
-              React.createElement('p', { className: "text-sm text-gray-600 mb-3" }, "點擊座位區塊，然後點擊個別座位來移除"),
-              selectedBlock && selectedBlock.type === 'seat' && React.createElement('button', {
-                onClick: restoreAllSeats,
-                className: "w-full bg-green-600 text-white p-2 rounded-md hover:bg-green-700"
-              }, "恢復所有座位")
-            ),
-            
-            designMode === 'pan' && React.createElement('div', null,
-              React.createElement('p', { className: "text-sm text-gray-600 mb-3" }, "拖拉畫布來移動視野，探索整個會場空間"),
-              React.createElement('div', { className: "bg-blue-50 border border-blue-200 rounded-md p-3" },
-                React.createElement('h4', { className: "text-sm font-medium text-blue-800 mb-2" }, "畫布位置"),
-                React.createElement('div', { className: "text-xs text-blue-600" },
-                  React.createElement('div', null, "X偏移: " + Math.round(viewOffset.x) + "px"),
-                  React.createElement('div', null, "Y偏移: " + Math.round(viewOffset.y) + "px")
-                ),
-                React.createElement('button', {
-                  onClick: () => setViewOffset({ x: 0, y: 0 }),
-                  className: "mt-2 w-full bg-blue-600 text-white text-xs py-1 px-2 rounded hover:bg-blue-700"
-                }, "重置視野")
-              )
-            ),
-            
-            selectedBlock && React.createElement('div', { className: "mt-4 pt-4 border-t" },
-              React.createElement('p', { className: "text-sm text-gray-600 mb-2" }, "選中區塊"),
-              React.createElement('p', { className: "font-medium" }, selectedBlock.label),
-              React.createElement('button', {
-                onClick: deleteSelectedBlock,
-                className: "w-full mt-2 bg-red-600 text-white p-2 rounded-md hover:bg-red-700"
-              }, "刪除區塊")
-            )
-          ),
+          mode === 'design' && React.createElement(SeatTools, {
+            designMode,
+            toolStyles,
+            currentTool,
+            setCurrentTool,
+            selectedBlock,
+            restoreAllSeats,
+            deleteSelectedBlock,
+            viewOffset,
+            setViewOffset
+          }),
           
           // 群體管理
           mode === 'assign' && React.createElement('div', { className: "bg-white rounded-lg shadow-md p-4" },
@@ -1159,31 +1055,7 @@ const SeatingDesigner = () => {
           ),
           
           // 導出功能
-          React.createElement('div', { className: "bg-white rounded-lg shadow-md p-4" },
-            React.createElement('h3', { className: "font-semibold mb-3" }, "導出功能"),
-            React.createElement('div', { className: "space-y-2" },
-              React.createElement('button', {
-                onClick: exportToPNG,
-                className: "w-full bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 flex items-center justify-center",
-                disabled: blocks.length === 0
-              },
-                React.createElement(Save, { className: "w-4 h-4 mr-2" }),
-                "導出PNG圖片"
-              ),
-              React.createElement('button', {
-                onClick: exportToCSV,
-                className: "w-full bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 flex items-center justify-center",
-                disabled: blocks.length === 0
-              },
-                React.createElement(Download, { className: "w-4 h-4 mr-2" }),
-                "導出布局表格"
-              )
-            ),
-            React.createElement('div', { className: "text-xs text-gray-500 mt-2 space-y-1" },
-              React.createElement('p', null, "• PNG：完整會場佈局圖片，包含標題和圖例"),
-              React.createElement('p', null, "• 布局表格：Excel 可開啟的座位圖表格，顯示座位編號和分配")
-            )
-          ),
+          React.createElement(ExportPanel, { blocks, exportToPNG, exportToCSV }),
           
           // 操作按鈕
           mode === 'assign' && React.createElement('div', { className: "bg-white rounded-lg shadow-md p-4" },

--- a/src/components/ExportPanel.jsx
+++ b/src/components/ExportPanel.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Save, Download } from "../icons";
+
+const ExportPanel = ({ blocks, exportToPNG, exportToCSV }) => (
+  React.createElement('div', { className: "bg-white rounded-lg shadow-md p-4" },
+    React.createElement('h3', { className: "font-semibold mb-3" }, "導出功能"),
+    React.createElement('div', { className: "space-y-2" },
+      React.createElement('button', {
+        onClick: exportToPNG,
+        className: "w-full bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 flex items-center justify-center",
+        disabled: blocks.length === 0
+      },
+        React.createElement(Save, { className: "w-4 h-4 mr-2" }),
+        "導出PNG圖片"
+      ),
+      React.createElement('button', {
+        onClick: exportToCSV,
+        className: "w-full bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 flex items-center justify-center",
+        disabled: blocks.length === 0
+      },
+        React.createElement(Download, { className: "w-4 h-4 mr-2" }),
+        "導出布局表格"
+      )
+    ),
+    React.createElement('div', { className: "text-xs text-gray-500 mt-2 space-y-1" },
+      React.createElement('p', null, "• PNG：完整會場佈局圖片，包含標題和圖例"),
+      React.createElement('p', null, "• 布局表格：Excel 可開啟的座位圖表格，顯示座位編號和分配")
+    )
+  )
+);
+
+export default ExportPanel;

--- a/src/components/SeatTools.jsx
+++ b/src/components/SeatTools.jsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { Plus } from "../icons";
+
+const SeatTools = ({
+  designMode,
+  toolStyles,
+  currentTool,
+  setCurrentTool,
+  selectedBlock,
+  restoreAllSeats,
+  deleteSelectedBlock,
+  viewOffset,
+  setViewOffset
+}) => (
+  React.createElement('div', { className: "bg-white rounded-lg shadow-md p-4" },
+    React.createElement('h3', { className: "font-semibold mb-3" }, "設計工具"),
+
+    designMode === 'create' && React.createElement('div', { className: "space-y-2" },
+      Object.entries(toolStyles).map(([tool, style]) =>
+        React.createElement('button', {
+          key: tool,
+          onClick: () => setCurrentTool(tool),
+          className: `w-full p-3 rounded-md border-2 flex items-center ${currentTool === tool ? 'border-blue-500 bg-blue-50' : 'border-gray-200 hover:border-gray-300'}`
+        },
+          React.createElement('div', {
+            className: "w-4 h-4 rounded mr-3",
+            style: { backgroundColor: style.color }
+          }),
+          style.label
+        )
+      ),
+      currentTool === 'seat' && React.createElement('div', { className: "mt-4 pt-4 border-t" },
+        React.createElement('p', { className: "text-xs text-gray-500" },
+          "座位數量完全根據拖拉區域大小決定，座位編號會自動連續排列"
+        )
+      )
+    ),
+
+    designMode === 'move' && React.createElement('p', { className: "text-sm text-gray-600" }, "點擊並拖動區塊來移動位置"),
+
+    designMode === 'edit' && React.createElement('div', null,
+      React.createElement('p', { className: "text-sm text-gray-600 mb-3" }, "點擊座位區塊，然後點擊個別座位來移除"),
+      selectedBlock && selectedBlock.type === 'seat' && React.createElement('button', {
+        onClick: restoreAllSeats,
+        className: "w-full bg-green-600 text-white p-2 rounded-md hover:bg-green-700"
+      }, "恢復所有座位")
+    ),
+
+    designMode === 'pan' && React.createElement('div', null,
+      React.createElement('p', { className: "text-sm text-gray-600 mb-3" }, "拖拉畫布來移動視野，探索整個會場空間"),
+      React.createElement('div', { className: "bg-blue-50 border border-blue-200 rounded-md p-3" },
+        React.createElement('h4', { className: "text-sm font-medium text-blue-800 mb-2" }, "畫布位置"),
+        React.createElement('div', { className: "text-xs text-blue-600" },
+          React.createElement('div', null, "X偏移: " + Math.round(viewOffset.x) + "px"),
+          React.createElement('div', null, "Y偏移: " + Math.round(viewOffset.y) + "px")
+        ),
+        React.createElement('button', {
+          onClick: () => setViewOffset({ x: 0, y: 0 }),
+          className: "mt-2 w-full bg-blue-600 text-white text-xs py-1 px-2 rounded hover:bg-blue-700"
+        }, "重置視野")
+      )
+    ),
+
+    selectedBlock && React.createElement('div', { className: "mt-4 pt-4 border-t" },
+      React.createElement('p', { className: "text-sm text-gray-600 mb-2" }, "選中區塊"),
+      React.createElement('p', { className: "font-medium" }, selectedBlock.label),
+      React.createElement('button', {
+        onClick: deleteSelectedBlock,
+        className: "w-full mt-2 bg-red-600 text-white p-2 rounded-md hover:bg-red-700"
+      }, "刪除區塊")
+    )
+  )
+);
+
+export default SeatTools;

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Users, Plus, Edit3, Hand, Move } from "../icons";
+
+const Toolbar = ({ mode, setMode, designMode, setDesignMode }) => (
+  React.createElement(React.Fragment, null,
+    React.createElement('div', { className: "bg-white rounded-lg shadow-md p-6 mb-6" },
+      React.createElement('h1', { className: "text-2xl font-bold text-gray-800 mb-2 flex items-center" },
+        React.createElement(Users, { className: "mr-3 text-blue-600" }),
+        "會場座位設計系統"
+      ),
+      React.createElement('p', { className: "text-gray-600" }, "拖拉設計會場佈局，智慧分配座位，支援缺角座位設計")
+    ),
+    React.createElement('div', { className: "bg-white rounded-lg shadow-md p-4 mb-6" },
+      React.createElement('div', { className: "flex space-x-4" },
+        React.createElement('button', {
+          onClick: () => setMode('design'),
+          className: `px-4 py-2 rounded-md flex items-center ${mode === 'design' ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-700'}`
+        },
+          React.createElement(Edit3, { className: "w-4 h-4 mr-2" }),
+          "設計模式"
+        ),
+        React.createElement('button', {
+          onClick: () => setMode('assign'),
+          className: `px-4 py-2 rounded-md flex items-center ${mode === 'assign' ? 'bg-green-600 text-white' : 'bg-gray-200 text-gray-700'}`
+        },
+          React.createElement(Users, { className: "w-4 h-4 mr-2" }),
+          "分配模式"
+        )
+      ),
+      mode === 'design' && React.createElement('div', { className: "flex space-x-2 mt-4 pt-4 border-t" },
+        React.createElement('button', {
+          onClick: () => setDesignMode('create'),
+          className: `px-3 py-2 rounded-md flex items-center text-sm ${designMode === 'create' ? 'bg-purple-600 text-white' : 'bg-gray-100 text-gray-700'}`
+        },
+          React.createElement(Plus, { className: "w-4 h-4 mr-1" }),
+          "創建區塊"
+        ),
+        React.createElement('button', {
+          onClick: () => setDesignMode('move'),
+          className: `px-3 py-2 rounded-md flex items-center text-sm ${designMode === 'move' ? 'bg-purple-600 text-white' : 'bg-gray-100 text-gray-700'}`
+        },
+          React.createElement(Hand, { className: "w-4 h-4 mr-1" }),
+          "移動區塊"
+        ),
+        React.createElement('button', {
+          onClick: () => setDesignMode('edit'),
+          className: `px-3 py-2 rounded-md flex items-center text-sm ${designMode === 'edit' ? 'bg-purple-600 text-white' : 'bg-gray-100 text-gray-700'}`
+        },
+          React.createElement(Edit3, { className: "w-4 h-4 mr-1" }),
+          "編輯座位"
+        ),
+        React.createElement('button', {
+          onClick: () => setDesignMode('pan'),
+          className: `px-3 py-2 rounded-md flex items-center text-sm ${designMode === 'pan' ? 'bg-purple-600 text-white' : 'bg-gray-100 text-gray-700'}`
+        },
+          React.createElement(Move, { className: "w-4 h-4 mr-1" }),
+          "移動畫布"
+        )
+      )
+    )
+  )
+);
+
+export default Toolbar;


### PR DESCRIPTION
## Summary
- split UI logic into `Toolbar`, `SeatTools` and `ExportPanel`
- place new components in `src/components`
- use new components inside `SeatingDesigner`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525fbf42ec8325a5f9ee68e8a98b49